### PR TITLE
Allow 0 for decimals

### DIFF
--- a/src/toBn.ts
+++ b/src/toBn.ts
@@ -15,7 +15,7 @@ export function toBn(x: string, decimals: number = 18): BigNumber {
   }
 
   if (decimals < 0 || decimals > 77) {
-    throw new Error("Decimals must be between 1 and 77");
+    throw new Error("Decimals must be between 0 and 77");
   }
 
   let xs: string = x;

--- a/src/toBn.ts
+++ b/src/toBn.ts
@@ -14,7 +14,7 @@ export function toBn(x: string, decimals: number = 18): BigNumber {
     throw new Error("Input must be a string");
   }
 
-  if (decimals < 1 || decimals > 77) {
+  if (decimals < 0 || decimals > 77) {
     throw new Error("Decimals must be between 1 and 77");
   }
 
@@ -34,7 +34,7 @@ export function toBn(x: string, decimals: number = 18): BigNumber {
 
   // Check if x is a whole number or a fixed-point number with some maximum number of decimals.
   const digits: number = 78 - decimals;
-  const regexp: RegExp = new RegExp(`^[-+]?(\\d{1,${digits}}|(?=\\d+\\.\\d+)\\d{1,${digits}}\\.\\d{1,${decimals}})$`);
+  const regexp: RegExp = new RegExp(`^[-+]?(\\d{1,${digits}}|(?=\\d+\\.\\d+)\\d{1,${digits}}\\.\\d{0,${decimals}})$`);
 
   if (regexp.test(xs)) {
     return parseFixed(xs, decimals);


### PR DESCRIPTION
That way, `toBn("100e6", 0)` will return "100000000" which is the real mathematical value.
I couldn't find any way to do that without this PR, but let me know otherwise.
